### PR TITLE
Add non-breaking standard RSA decryption

### DIFF
--- a/src/api/modules/decrypt/decrypt.background.ts
+++ b/src/api/modules/decrypt/decrypt.background.ts
@@ -6,68 +6,101 @@ import Arweave from "arweave";
 const background: ModuleFunction<string> = async (
   _,
   data: Uint8Array,
-  options: {
-    algorithm: string;
-    hash: string;
-    salt?: string;
-  }
+  options: any
 ) => {
-  // grab the user's keyfile
-  const { keyfile } = await getActiveKeyfile().catch(() => {
-    // if there are no wallets added, open the welcome page
-    browser.tabs.create({ url: browser.runtime.getURL("/welcome.html") });
+  if (options.algorithm) {
+    // Old ArConnect algorithm
+    // grab the user's keyfile
+    const { keyfile } = await getActiveKeyfile().catch(() => {
+      // if there are no wallets added, open the welcome page
+      browser.tabs.create({
+        url: browser.runtime.getURL("/welcome.html")
+      });
 
-    throw new Error("No wallets added");
-  });
+      throw new Error("No wallets added");
+    });
 
-  // get decryption key
-  const decryptJwk = {
-    ...keyfile,
-    alg: "RSA-OAEP-256",
-    ext: true
-  };
-  const key = await crypto.subtle.importKey(
-    "jwk",
-    decryptJwk,
-    {
-      name: options.algorithm,
-      hash: {
-        name: options.hash
-      }
-    },
-    false,
-    ["decrypt"]
-  );
+    // get decryption key
+    const decryptJwk = {
+      ...keyfile,
+      alg: "RSA-OAEP-256",
+      ext: true
+    };
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      decryptJwk,
+      {
+        name: options.algorithm,
+        hash: {
+          name: options.hash
+        }
+      },
+      false,
+      ["decrypt"]
+    );
 
-  // prepare encrypted data
-  const encryptedKey = new Uint8Array(
-    new Uint8Array(Object.values(data)).slice(0, 512)
-  );
-  const encryptedData = new Uint8Array(
-    new Uint8Array(Object.values(data)).slice(512)
-  );
+    // prepare encrypted data
+    const encryptedKey = new Uint8Array(
+      new Uint8Array(Object.values(data)).slice(0, 512)
+    );
+    const encryptedData = new Uint8Array(
+      new Uint8Array(Object.values(data)).slice(512)
+    );
 
-  // create arweave client
-  const arweave = new Arweave(await getArweaveConfig());
+    // create arweave client
+    const arweave = new Arweave(await getArweaveConfig());
 
-  // decrypt data
-  const symmetricKey = await crypto.subtle.decrypt(
-    { name: options.algorithm },
-    key,
-    encryptedKey
-  );
+    // decrypt data
+    const symmetricKey = await crypto.subtle.decrypt(
+      {
+        name: options.algorithm
+      },
+      key,
+      encryptedKey
+    );
 
-  const res = await arweave.crypto.decrypt(
-    encryptedData,
-    new Uint8Array(symmetricKey)
-  );
+    const res = await arweave.crypto.decrypt(
+      encryptedData,
+      new Uint8Array(symmetricKey)
+    );
 
-  // if a salt is present, split it from the decrypted string
-  if (options.salt) {
-    return arweave.utils.bufferToString(res).split(options.salt)[0];
+    // if a salt is present, split it from the decrypted string
+    if (options.salt) {
+      return arweave.utils.bufferToString(res).split(options.salt)[0];
+    }
+
+    return arweave.utils.bufferToString(res);
+  } else if (options.name) {
+    //Standard RSA decryption, from arweave.app
+    const { keyfile } = await getActiveKeyfile().catch(() => {
+      // if there are no wallets added, open the welcome page
+      browser.tabs.create({
+        url: browser.runtime.getURL("/welcome.html")
+      });
+
+      throw new Error("No wallets added");
+    });
+    const decryptJwk = {
+      ...keyfile,
+      alg: undefined,
+      key_ops: undefined,
+      ext: true
+    };
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      decryptJwk,
+      {
+        name: "RSA-OAEP",
+        hash: "SHA-256"
+      },
+      false,
+      ["decrypt"]
+    );
+    const decrypted = await window.crypto.subtle.decrypt(options, key, data);
+    return new Uint8Array(decrypted);
+  } else {
+    throw new Error("Invalid options passed!", options);
   }
-
-  return arweave.utils.bufferToString(res);
 };
 
 export default background;


### PR DESCRIPTION
Closes #90, detects what decryption way app wants to use (standard RSA one, like arweave.app uses, or old ArConnect one with AES in the middle), and uses it. 