### PR TITLE
0.5.2

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -139,35 +139,25 @@ Dispatches (signs and sends) a transaction to the network, preferably by bundlin
 
 Requires the `DISPATCH` [permission](#permissions).
 
-### `encrypt(data, options): Promise<Uint8Array>`
+### `encrypt(data, algorithm): Promise<Uint8Array>`
 
-Encrypt a string with the user's wallet.
+Encrypt data with the user's wallet. This is an implementation of the [webcrypto encrypt API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt).
 
-- `data`: String to encrypt
-- `options`: Encrypt [options](#encryption-options)
+- `data`: `BufferSource` to encrypt
+- `algorithm`: Encrypt [algorithm](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt#parameters)
   <br />
-- `returns`: Encrypted string
+- `returns`: Encrypted data
 
 Requires the `ENCRYPT` [permission](#permissions).
 
-#### Encryption options
-
-```ts
-{
-  algorithm: string; // encryption algorithm
-  hash: string; // encryption hash
-  salt?: string; // optional salt
-}
-```
-
 ### `decrypt(data, options): Promise<string>`
 
-Decrypt a string [encrypted](#encryptdata-options-promiseuint8array) with the user's wallet.
+Decrypt data with the user's wallet. This is an implementation of the [webcrypto decrypt API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/decrypt).
 
-- `data`: `Uint8Array` data to decrypt to a string
-- `options`: Decrypt [options](#encryption-options)
+- `data`: `BufferSource` data to decrypt
+- `algorithm`: Decrypt [algorithm](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/decrypt#parameters)
   <br />
-- `returns`: Decrypted string
+- `returns`: Decrypted data
 
 Requires the `DECRYPT` [permission](#permissions).
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ arconnect.zip
 public.zip
 *.crx
 *.pem
+.plasmo

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,7 +11,9 @@
     "contextMenus",
     "<all_urls>",
     "alarms",
-    "notifications"
+    "notifications",
+    "webRequest",
+    "webRequestBlocking"
   ],
   "background": {
     "scripts": ["build/scripts/background.js"]

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ArConnect",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "th8ta",
   "description": "Secure wallet management for Arweave",
   "permissions": [

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "ArConnect",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "th8ta",
   "description": "Secure wallet management for Arweave",
   "permissions": [

--- a/src/api/modules/decrypt/decrypt.background.ts
+++ b/src/api/modules/decrypt/decrypt.background.ts
@@ -5,7 +5,7 @@ import Arweave from "arweave";
 
 const background: ModuleFunction<string | Uint8Array> = async (
   _,
-  data: Uint8Array,
+  data: BufferSource,
   options: any
 ) => {
   // grab the user's keyfile

--- a/src/api/modules/decrypt/decrypt.foreground.ts
+++ b/src/api/modules/decrypt/decrypt.foreground.ts
@@ -2,7 +2,9 @@ import { ModuleFunction } from "../../module";
 
 const foreground: ModuleFunction<void> = (_, options) => {
   if (options.algorithm) {
-    console.warn("[ArConnect] YOU'RE USING DEPRECATED PARAMS FOR \"decrypt()\". Please check the documentation.\nhttps://github.com/arconnectio/ArConnect#decryptdata-options-promisestring");
+    console.warn(
+      '[ArConnect] YOU\'RE USING DEPRECATED PARAMS FOR "decrypt()". Please check the documentation.\nhttps://github.com/arconnectio/ArConnect#decryptdata-options-promisestring'
+    );
   }
 };
 

--- a/src/api/modules/decrypt/decrypt.foreground.ts
+++ b/src/api/modules/decrypt/decrypt.foreground.ts
@@ -1,6 +1,9 @@
 import { ModuleFunction } from "../../module";
 
-// no need to transform anything in the foreground
-const foreground: ModuleFunction<void> = () => {};
+const foreground: ModuleFunction<void> = (_, options) => {
+  if (options.algorithm) {
+    console.warn("[ArConnect] YOU'RE USING DEPRECATED PARAMS FOR \"decrypt()\". Please check the documentation.\nhttps://github.com/arconnectio/ArConnect#decryptdata-options-promisestring");
+  }
+};
 
 export default foreground;

--- a/src/api/modules/encrypt/encrypt.background.ts
+++ b/src/api/modules/encrypt/encrypt.background.ts
@@ -5,12 +5,8 @@ import Arweave from "arweave";
 
 const background: ModuleFunction<Uint8Array> = async (
   _,
-  data: string,
-  options: {
-    algorithm: string;
-    hash: string;
-    salt?: string;
-  }
+  data: string | BufferSource,
+  options: any
 ) => {
   // grab the user's keyfile
   const { keyfile } = await getActiveKeyfile().catch(() => {
@@ -20,47 +16,73 @@ const background: ModuleFunction<Uint8Array> = async (
     throw new Error("No wallets added");
   });
 
-  // get encryption key
-  const encryptJwk = {
-    kty: "RSA",
-    e: "AQAB",
-    n: keyfile.n,
-    alg: "RSA-OAEP-256",
-    ext: true
-  };
-  const key = await crypto.subtle.importKey(
-    "jwk",
-    encryptJwk,
-    {
-      name: options.algorithm,
-      hash: {
-        name: options.hash
-      }
-    },
-    false,
-    ["encrypt"]
-  );
+  if (options.algorithm) {
+    // old arconnect algorithm
+    // get encryption key
+    const encryptJwk = {
+      kty: "RSA",
+      e: "AQAB",
+      n: keyfile.n,
+      alg: "RSA-OAEP-256",
+      ext: true
+    };
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      encryptJwk,
+      {
+        name: options.algorithm,
+        hash: {
+          name: options.hash
+        }
+      },
+      false,
+      ["encrypt"]
+    );
 
-  // prepare data
-  const dataBuf = new TextEncoder().encode(data + (options.salt || ""));
-  const array = new Uint8Array(256);
+    // prepare data
+    const dataBuf = new TextEncoder().encode(data + (options.salt || ""));
+    const array = new Uint8Array(256);
 
-  crypto.getRandomValues(array);
+    crypto.getRandomValues(array);
 
-  const keyBuf = array;
+    const keyBuf = array;
 
-  // create arweave client
-  const arweave = new Arweave(await getArweaveConfig());
+    // create arweave client
+    const arweave = new Arweave(await getArweaveConfig());
 
-  // encrypt data
-  const encryptedData = await arweave.crypto.encrypt(dataBuf, keyBuf);
-  const encryptedKey = await crypto.subtle.encrypt(
-    { name: options.algorithm },
-    key,
-    keyBuf
-  );
+    // encrypt data
+    const encryptedData = await arweave.crypto.encrypt(dataBuf, keyBuf);
+    const encryptedKey = await crypto.subtle.encrypt(
+      { name: options.algorithm },
+      key,
+      keyBuf
+    );
 
-  return arweave.utils.concatBuffers([encryptedKey, encryptedData]);
+    return arweave.utils.concatBuffers([encryptedKey, encryptedData]);
+  } else if (options.name && typeof data !== "string") {
+    // standard RSA decryption
+    const encryptJwk = {
+      ...keyfile,
+      alg: undefined,
+      key_ops: undefined,
+      ext: true
+    };
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      encryptJwk,
+      {
+        name: "RSA-OAEP",
+        hash: "SHA-256"
+      },
+      false,
+      ["encrypt"]
+    );
+    const encrypted = await window.crypto.subtle.encrypt(options, key, data);
+
+    return new Uint8Array(encrypted);
+  } else {
+    throw new Error("Invalid options passed", options);
+  }
 };
 
 export default background;

--- a/src/api/modules/encrypt/encrypt.foreground.ts
+++ b/src/api/modules/encrypt/encrypt.foreground.ts
@@ -3,7 +3,9 @@ import { ModuleFunction } from "../../module";
 
 const foreground: ModuleFunction<void> = (_, options) => {
   if (options.algorithm) {
-    console.warn("[ArConnect] YOU'RE USING DEPRECATED PARAMS FOR \"encrypt()\". Please check the documentation.\nhttps://github.com/arconnectio/ArConnect#encryptdata-options-promiseuint8array");
+    console.warn(
+      '[ArConnect] YOU\'RE USING DEPRECATED PARAMS FOR "encrypt()". Please check the documentation.\nhttps://github.com/arconnectio/ArConnect#encryptdata-options-promiseuint8array'
+    );
   }
 };
 

--- a/src/api/modules/encrypt/encrypt.foreground.ts
+++ b/src/api/modules/encrypt/encrypt.foreground.ts
@@ -1,8 +1,11 @@
 import { TransformFinalizer } from "../../foreground";
 import { ModuleFunction } from "../../module";
 
-// no need to transform anything in the foreground
-const foreground: ModuleFunction<void> = () => {};
+const foreground: ModuleFunction<void> = (_, options) => {
+  if (options.algorithm) {
+    console.warn("[ArConnect] YOU'RE USING DEPRECATED PARAMS FOR \"encrypt()\". Please check the documentation.\nhttps://github.com/arconnectio/ArConnect#encryptdata-options-promiseuint8array");
+  }
+};
 
 export const finalizer: TransformFinalizer<Record<any, any>, any, any> = (
   result

--- a/src/ar_protocol/index.ts
+++ b/src/ar_protocol/index.ts
@@ -1,0 +1,55 @@
+import { WebRequest, browser } from "webextension-polyfill-ts";
+import { IGatewayConfig } from "../stores/reducers/arweave"
+import { getRedirectURL } from "./parser";
+
+/**
+ * Add handler for the "ar://" protocol for
+ * mv2 based browsers.
+ */
+export default async function addHandler() {
+  browser.webRequest.onBeforeRequest.addListener(
+    middleware,
+    { urls: ["<all_urls>"], types: ["main_frame", "sub_frame"] },
+    ["blocking"]
+  );
+}
+
+/**
+ * Disable handler for "ar://" protocol
+ */
+export async function disableHandler() {
+  if (!browser.webRequest.onBeforeRequest.hasListener(middleware)) {
+    return;
+  }
+
+  browser.webRequest.onBeforeRequest.removeListener(middleware);
+}
+
+/**
+ * Add middleware that redirects to
+ * the appropriate arweave tx, permapage
+ * URL or ANS name
+ */
+async function middleware(
+  details: WebRequest.OnBeforeRequestDetailsType
+): Promise<WebRequest.BlockingResponse> {
+  if (!mayContainArProtocol(details)) return {};
+
+  const url = new URL(details.url);
+  // TODO: get active gateway
+  const gateway: IGatewayConfig = {
+    host: "arweave.net",
+    port: 443,
+    protocol: "https"
+  };
+
+  // parse redirect url
+  const redirectUrl = getRedirectURL(url, gateway);
+
+  if (!redirectUrl) return {};
+
+  return { redirectUrl };
+}
+
+const mayContainArProtocol = (request: WebRequest.OnBeforeRequestDetailsType) =>
+  request.url.includes(encodeURIComponent("ar://"));

--- a/src/ar_protocol/index.ts
+++ b/src/ar_protocol/index.ts
@@ -48,6 +48,12 @@ async function middleware(
 
   if (!redirectUrl) return {};
 
+  // @ts-expect-error
+  if (chrome) {
+    browser.tabs.update(details.tabId, { url: redirectUrl });
+    return {};
+  }
+
   return { redirectUrl };
 }
 

--- a/src/ar_protocol/index.ts
+++ b/src/ar_protocol/index.ts
@@ -1,5 +1,5 @@
 import { WebRequest, browser } from "webextension-polyfill-ts";
-import { IGatewayConfig } from "../stores/reducers/arweave"
+import { IGatewayConfig } from "../stores/reducers/arweave";
 import { getRedirectURL } from "./parser";
 
 /**

--- a/src/ar_protocol/parser.ts
+++ b/src/ar_protocol/parser.ts
@@ -1,5 +1,5 @@
-import { IGatewayConfig } from "../stores/reducers/arweave"
-import { concatGatewayURL } from "../utils/gateways"
+import { IGatewayConfig } from "../stores/reducers/arweave";
+import { concatGatewayURL } from "../utils/gateways";
 
 export function getRedirectURL(url: URL, gateway: IGatewayConfig) {
   let redirectURL: string | undefined = undefined;

--- a/src/ar_protocol/parser.ts
+++ b/src/ar_protocol/parser.ts
@@ -1,0 +1,29 @@
+import { IGatewayConfig } from "../stores/reducers/arweave"
+import { concatGatewayURL } from "../utils/gateways"
+
+export function getRedirectURL(url: URL, gateway: IGatewayConfig) {
+  let redirectURL: string | undefined = undefined;
+
+  // "ar://" url
+  const arURL = url.searchParams.get("q");
+
+  if (!arURL || arURL === "") {
+    return redirectURL;
+  }
+
+  // value (address / permapage / id)
+  const value = arURL.replace("ar://", "");
+
+  if (!value || value === "") {
+    return redirectURL;
+  }
+
+  redirectURL = concatGatewayURL(gateway) + "/" + value;
+
+  // if it is not an Arweave ID, redirect to permapages
+  if (!/[a-z0-9_-]{43}/i.test(value)) {
+    redirectURL = `https://${value}.arweave.dev`;
+  }
+
+  return redirectURL;
+}

--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -19,6 +19,7 @@ import { browser } from "webextension-polyfill-ts";
 import { ArConnectEvent } from "../views/Popup/routes/Settings";
 import { Chunk, handleChunk } from "../api/modules/sign/chunks";
 import { getRealURL } from "../utils/url";
+import addProtocolHandler from "../ar_protocol";
 import handleFeeAlarm from "../utils/fee";
 import modules from "../api/background";
 
@@ -249,5 +250,8 @@ browser.runtime.onMessage.addListener(async (message: MessageFormat) => {
       break;
   }
 });
+
+// add ar:// protocol
+addProtocolHandler();
 
 export {};

--- a/src/utils/background.ts
+++ b/src/utils/background.ts
@@ -1,4 +1,4 @@
-import { MessageType, validateMessage } from "../utils/messenger";
+import { validateMessage } from "../utils/messenger";
 import { RootState } from "../stores/reducers";
 import { IPermissionState } from "../stores/reducers/permissions";
 import { IGatewayConfig, defaultConfig } from "../stores/reducers/arweave";
@@ -134,7 +134,7 @@ export async function walletsStored(): Promise<boolean> {
  * @param action Reason of the auth request
  * @param tabURL The URL of the current app
  */
-export const authenticateUser = (action: MessageType, tabURL: string) =>
+export const authenticateUser = (action: string, tabURL: string) =>
   new Promise<void>(async (resolve, reject) => {
     try {
       const decryptionKey = (await browser.storage.local.get("decryptionKey"))

--- a/src/views/Popup/routes/Settings.tsx
+++ b/src/views/Popup/routes/Settings.tsx
@@ -29,7 +29,6 @@ import { RootState } from "../../../stores/reducers";
 import { formatAddress, getRealURL, shortenURL } from "../../../utils/url";
 import { Currency } from "../../../stores/reducers/settings";
 import { Threshold } from "arverify";
-import { MessageType } from "../../../utils/messenger";
 import { updateIcon } from "../../../scripts/background/icon";
 import { checkPassword, setPassword } from "../../../utils/auth";
 import { browser } from "webextension-polyfill-ts";
@@ -1324,7 +1323,7 @@ export default function Settings({
 }
 
 export interface ArConnectEvent {
-  event: MessageType;
+  event: string;
   url: string;
   date: number;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -81,11 +81,7 @@ declare global {
        */
       encrypt(
         data: string,
-        options: {
-          algorithm: string;
-          hash: string;
-          salt?: string;
-        }
+        options: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
       ): Promise<Uint8Array>;
 
       /**
@@ -98,11 +94,7 @@ declare global {
        */
       decrypt(
         data: Uint8Array,
-        options: {
-          algorithm: string;
-          hash: string;
-          salt?: string;
-        }
+        options: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
       ): Promise<string>;
 
       /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -76,9 +76,9 @@ declare global {
        *
        * @param data `BufferSource` data to encrypt
        * @param options Encrypt algorithm
-       *  
+       *
        * This is an implementation of the [webcrypto encrypt API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt).
-       * 
+       *
        * @returns Promise of the encrypted data
        */
       encrypt(
@@ -91,7 +91,7 @@ declare global {
        *
        * @param data `BufferSource` data to decrypt
        * @param options Decrypt algorithm
-       * 
+       *
        * This is an implementation of the [webcrypto decrypt API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/decrypt).
        *
        * @returns Promise of the decrypted data

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -72,30 +72,34 @@ declare global {
       getPermissions(): Promise<PermissionType[]>;
 
       /**
-       * Encrypt a string, using the user's wallet.
+       * Encrypt data, using the user's wallet.
        *
-       * @param data String to encrypt
-       * @param options Encrypt options
-       *
-       * @returns Promise of the encrypted string
+       * @param data `BufferSource` data to encrypt
+       * @param options Encrypt algorithm
+       *  
+       * This is an implementation of the [webcrypto encrypt API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/encrypt).
+       * 
+       * @returns Promise of the encrypted data
        */
       encrypt(
-        data: string,
-        options: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
+        data: BufferSource,
+        algorithm: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
       ): Promise<Uint8Array>;
 
       /**
-       * Decrypt a string encrypted with the user's wallet.
+       * Decrypt data encrypted with the user's wallet.
        *
-       * @param data `Uint8Array` data to decrypt to a string
-       * @param options Decrypt options
+       * @param data `BufferSource` data to decrypt
+       * @param options Decrypt algorithm
+       * 
+       * This is an implementation of the [webcrypto decrypt API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/decrypt).
        *
-       * @returns Promise of the decrypted string
+       * @returns Promise of the decrypted data
        */
       decrypt(
-        data: Uint8Array,
-        options: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
-      ): Promise<string>;
+        data: BufferSource,
+        algorithm: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
+      ): Promise<Uint8Array>;
 
       /**
        * Get the user's custom Arweave config set in the extension

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arconnect",
-  "version": "0.4.2",
+  "version": "0.5.2",
   "main": "index.js",
   "module": "index.es.js",
   "jsnext:main": "index.es.js",


### PR DESCRIPTION
- Add support for "ar://" protocol
- Refactor encrypt/decrypt
- Deprecated old encrypt/decrypt (API is still compatible)

Notes about the new permissions:
We are using two new permissions in this version: "webRequest" and "webRequestBlocking". These permissions allow us to redirect requests from "ar://" protocol. See the implementation [here](https://github.com/arconnectio/ArConnect/blob/a18f3c572c6d46020f607d9b4a5f0c9873051622/src/ar_protocol/index.ts#L10).