### PR TITLE
fix: default arConfetti config to name instead of full url

### DIFF
--- a/src/stores/reducers/settings.ts
+++ b/src/stores/reducers/settings.ts
@@ -17,7 +17,7 @@ export interface ISettingsAction {
 
 const defaultConfig: ISettings = {
   currency: "USD",
-  arConfetti: browser.runtime.getURL("assets/arweave.png"),
+  arConfetti: "arweave",
   arVerifyTreshold: Threshold.MEDIUM,
   feeMultiplier: 1,
   signNotification: false


### PR DESCRIPTION
In `src/api/modules/sign/utils.ts:29` icon already returned as joined with url, doing it again in the config was causing a duplication.

```js
return browser.runtime.getURL(`assets/${iconName}.png`);
```

Also fixes: https://github.com/arconnectio/ArConnect/issues/89