### PR TITLE
feat: added gateway change emitter

### DIFF
--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -248,6 +248,21 @@ browser.runtime.onMessage.addListener(async (message: MessageFormat) => {
       });
 
       break;
+      case "switch_gateway_event":
+        if (
+          !(await checkPermissions(
+            ["ACCESS_ARWEAVE_CONFIG"],
+            activeTab.url as string
+          ))
+        )
+          return;
+  
+        await browser.tabs.sendMessage(activeTab.id as number, {
+          ...message,
+          type: "switch_gateway_event_forward"
+        });
+  
+        break;
   }
 });
 

--- a/src/scripts/content.ts
+++ b/src/scripts/content.ts
@@ -66,6 +66,10 @@ browser.runtime.onMessage.addListener(async (message: MessageFormat) => {
   // handle wallet switch event
   if (validateMessage(message, "popup", "switch_wallet_event_forward"))
     window.postMessage(message, window.location.origin);
+      // handle gateway switch event
+  if (validateMessage(message, "popup", "switch_gateway_event_forward"))
+  window.postMessage(message, window.location.origin);
 });
+
 
 export {};

--- a/src/scripts/injected.ts
+++ b/src/scripts/injected.ts
@@ -18,6 +18,21 @@ window.addEventListener("message", ({ data }) => {
   );
 });
 
+window.addEventListener("message", ({ data }) => {
+  if (
+    !validateMessage(data, "popup", "switch_gateway_event_forward") ||
+    !data?.data?.config
+  ) {
+    return;
+  }
+
+  dispatchEvent(
+    new CustomEvent("gatewaySwitch", {
+      detail: { config: data.data.config }
+    })
+  );
+});
+
 /** Init wallet API */
 const WalletAPI: Record<string, any> = {
   walletName: "ArConnect",

--- a/src/views/Popup/routes/Settings.tsx
+++ b/src/views/Popup/routes/Settings.tsx
@@ -56,6 +56,7 @@ import axios from "axios";
 import manifest from "../../../../public/manifest.json";
 import SubPageTopStyles from "../../../styles/components/SubPageTop.module.sass";
 import styles from "../../../styles/views/Popup/settings.module.sass";
+import { MessageFormat } from "../../../utils/messenger";
 
 export default function Settings({
   initialSetting
@@ -205,6 +206,14 @@ export default function Settings({
             gateway: config
           })
         );
+        const message: MessageFormat = {
+          type: "switch_gateway_event",
+          ext: "arconnect",
+          data: { config },
+          origin: "popup"
+        };
+    
+        browser.runtime.sendMessage(message);
       }
     } catch {}
 


### PR DESCRIPTION
This pr adds a gateway change emitter to the settings route allowing for apps to listen to gateway changes if they have the required permissions. Works the same way as the walletSwitch listener:

`  window.addEventListener('gatewaySwitch', (e:any) => {
    const { host, protocol, port } = e.detail.config;
  })`

![image](https://github.com/arconnectio/ArConnect/assets/85306700/bd0e335d-dafa-42f0-924f-0eb18a7c6d84)
