### PR TITLE
fix: Prevent useEffect multiple executions

### DIFF
--- a/src/components/popup/WalletSwitcher.tsx
+++ b/src/components/popup/WalletSwitcher.tsx
@@ -96,7 +96,7 @@ export default function WalletSwitcher({
 
       setLoadedAns(true);
     })();
-  }, [wallets]);
+  }, [wallets.length]);
 
   // load wallet balances
   const [loadedBalances, setLoadedBalances] = useState(false);
@@ -130,7 +130,7 @@ export default function WalletSwitcher({
 
       setLoadedBalances(true);
     })();
-  }, [wallets]);
+  }, [wallets.length]);
 
   // toasts
   const { setToast } = useToasts();


### PR DESCRIPTION
# Fix

- Prevent multiple retriggers of the `useEffect` hook due to the use of `setWallets` inside useEffect and `wallets` being the dependency.